### PR TITLE
Fix income labels

### DIFF
--- a/childcare_form.json
+++ b/childcare_form.json
@@ -821,7 +821,7 @@
           "fields" :[
             {
               "id": "applicant_emp_income_indicator",
-              "label": "Does applicant earn any inomce/ wages from employment? ",
+              "label": "Does applicant earn any income/ wages from employment? ",
               "type": "radio",
               "required": false,
               "ui": {
@@ -830,7 +830,7 @@
             },
             {
               "id": "coparent_emp_income_indicator",
-              "label": "Does Coparent/2nd Guardian earn any inomce/ wages from employment? ",
+              "label": "Does Coparent/2nd Guardian earn any income/ wages from employment? ",
               "type": "radio",
               "required": false,
               "ui": {


### PR DESCRIPTION
## Summary
- correct employment precheck labels misspelling

## Testing
- `grep -n "inomce" childcare_form.json`

------
https://chatgpt.com/codex/tasks/task_e_684a2e7c585c8331b97f3e44241569a2