### PR TITLE
Use ReactMarkdown in InfoBlock

### DIFF
--- a/childcare-app/components/fields/InfoBlock.tsx
+++ b/childcare-app/components/fields/InfoBlock.tsx
@@ -1,12 +1,15 @@
+import ReactMarkdown from 'react-markdown'
+
 interface Props {
   title: string
   content: string
 }
+
 export default function InfoBlock({ title, content }: Props) {
   return (
     <div className="mb-6 p-4 bg-blue-50 border-l-4 border-blue-400">
       <h3 className="font-semibold mb-2">{title}</h3>
-      <div className="prose" dangerouslySetInnerHTML={{ __html: content }} />
+      <ReactMarkdown className="prose">{content}</ReactMarkdown>
     </div>
   )
 }

--- a/childcare-app/package.json
+++ b/childcare-app/package.json
@@ -15,7 +15,8 @@
     "classnames": "2.3.2",
     "react-hook-form": "7.49.2",
     "zod": "3.22.4",
-    "@hookform/resolvers": "3.1.2"
+    "@hookform/resolvers": "3.1.2",
+    "react-markdown": "latest"
   },
   "devDependencies": {
     "@types/react": "18.2.12",


### PR DESCRIPTION
## Summary
- add `react-markdown` dependency
- use `<ReactMarkdown>` instead of `dangerouslySetInnerHTML`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a437c932483319df257fb82e67b6c