### PR TITLE
Add tooltip support to form fields

### DIFF
--- a/childcare-app/components/fields/DateField.tsx
+++ b/childcare-app/components/fields/DateField.tsx
@@ -1,4 +1,5 @@
 import { useFormContext } from 'react-hook-form'
+import Tooltip from './Tooltip'
 interface Props {
   id: string
   label: string
@@ -13,7 +14,13 @@ export default function DateField({ id, label, required, tooltip }: Props) {
       <label htmlFor={id} className="block font-medium">
         {label} {required && <span className="text-red-600">*</span>}
       </label>
-      <input id={id} type="date" title={tooltip} {...register(id, { required })} className="border rounded p-2 w-full" />
+      {tooltip ? (
+        <Tooltip content={tooltip}>
+          <input id={id} type="date" title={tooltip} {...register(id, { required })} className="border rounded p-2 w-full" />
+        </Tooltip>
+      ) : (
+        <input id={id} type="date" title={tooltip} {...register(id, { required })} className="border rounded p-2 w-full" />
+      )}
       {errors[id] && (
         <p className="text-red-600 text-sm">This field is required.</p>
       )}

--- a/childcare-app/components/fields/SelectField.tsx
+++ b/childcare-app/components/fields/SelectField.tsx
@@ -1,4 +1,5 @@
 import { useFormContext } from 'react-hook-form'
+import Tooltip from './Tooltip'
 interface Props {
   id: string
   label: string
@@ -15,24 +16,50 @@ export default function SelectField({ id, label, options, required, multiple, to
       <label htmlFor={id} className="block font-medium">
         {label} {required && <span className="text-red-600">*</span>}
       </label>
-      <select
-        id={id}
-        multiple={multiple}
-        title={tooltip}
-        {...register(id, { required, onChange: e => {
-          if (multiple) {
-            const vals = Array.from(e.target.selectedOptions).map(o => o.value)
-            setValue(id, vals)
-          }
-        } })}
-        className="border rounded p-2 w-full"
-      >
-        {!multiple && <option value="">Select...</option>}
+      {tooltip ? (
+        <Tooltip content={tooltip}>
+          <select
+            id={id}
+            multiple={multiple}
+            title={tooltip}
+            {...register(id, {
+              required,
+              onChange: e => {
+                if (multiple) {
+                  const vals = Array.from(e.target.selectedOptions).map(o => o.value)
+                  setValue(id, vals)
+                }
+              }
+            })}
+            className="border rounded p-2 w-full"
+          >
+            {!multiple && <option value="">Select...</option>}
 
-        {options.map(opt => (
-          <option key={opt} value={opt}>{opt}</option>
-        ))}
-      </select>
+            {options.map(opt => (
+              <option key={opt} value={opt}>{opt}</option>
+            ))}
+          </select>
+        </Tooltip>
+      ) : (
+        <select
+          id={id}
+          multiple={multiple}
+          title={tooltip}
+          {...register(id, { required, onChange: e => {
+            if (multiple) {
+              const vals = Array.from(e.target.selectedOptions).map(o => o.value)
+              setValue(id, vals)
+            }
+          } })}
+          className="border rounded p-2 w-full"
+        >
+          {!multiple && <option value="">Select...</option>}
+
+          {options.map(opt => (
+            <option key={opt} value={opt}>{opt}</option>
+          ))}
+        </select>
+      )}
       {errors[id] && (
         <p className="text-red-600 text-sm">This field is required.</p>
       )}

--- a/childcare-app/components/fields/TextField.tsx
+++ b/childcare-app/components/fields/TextField.tsx
@@ -1,4 +1,5 @@
 import { useFormContext } from 'react-hook-form'
+import Tooltip from './Tooltip'
 interface Props {
   id: string
   label: string
@@ -17,15 +18,27 @@ export default function TextField({ id, label, type = 'text', required, placehol
       <label htmlFor={id} className="block font-medium">
         {label} {required && <span className="text-red-600">*</span>}
       </label>
-      <input
-        id={id}
-        type={type}
-        title={tooltip}
-        {...register(id, validation)}
-
-        placeholder={placeholder}
-        className="border rounded p-2 w-full"
-      />
+      {tooltip ? (
+        <Tooltip content={tooltip}>
+          <input
+            id={id}
+            type={type}
+            title={tooltip}
+            {...register(id, validation)}
+            placeholder={placeholder}
+            className="border rounded p-2 w-full"
+          />
+        </Tooltip>
+      ) : (
+        <input
+          id={id}
+          type={type}
+          title={tooltip}
+          {...register(id, validation)}
+          placeholder={placeholder}
+          className="border rounded p-2 w-full"
+        />
+      )}
       {errors[id] && (
         <p className="text-red-600 text-sm">This field is required.</p>
       )}

--- a/childcare-app/components/fields/TimeField.tsx
+++ b/childcare-app/components/fields/TimeField.tsx
@@ -1,4 +1,5 @@
 import { useFormContext } from 'react-hook-form'
+import Tooltip from './Tooltip'
 interface Props {
   id: string
   label: string
@@ -13,7 +14,13 @@ export default function TimeField({ id, label, required, tooltip }: Props) {
       <label htmlFor={id} className="block font-medium">
         {label} {required && <span className="text-red-600">*</span>}
       </label>
-      <input id={id} type="time" title={tooltip} {...register(id, { required })} className="border rounded p-2 w-full" />
+      {tooltip ? (
+        <Tooltip content={tooltip}>
+          <input id={id} type="time" title={tooltip} {...register(id, { required })} className="border rounded p-2 w-full" />
+        </Tooltip>
+      ) : (
+        <input id={id} type="time" title={tooltip} {...register(id, { required })} className="border rounded p-2 w-full" />
+      )}
 
       {errors[id] && (
         <p className="text-red-600 text-sm">This field is required.</p>

--- a/childcare-app/components/fields/Tooltip.tsx
+++ b/childcare-app/components/fields/Tooltip.tsx
@@ -1,0 +1,26 @@
+import { ReactNode, useState } from 'react'
+
+interface TooltipProps {
+  content: string
+  children: ReactNode
+}
+
+export default function Tooltip({ content, children }: TooltipProps) {
+  const [open, setOpen] = useState(false)
+  return (
+    <span
+      className="relative inline-block group"
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+      onFocus={() => setOpen(true)}
+      onBlur={() => setOpen(false)}
+    >
+      {children}
+      {open && (
+        <span className="absolute left-1/2 -translate-x-1/2 mt-1 whitespace-nowrap bg-black text-white text-xs rounded py-1 px-2 z-10">
+          {content}
+        </span>
+      )}
+    </span>
+  )
+}


### PR DESCRIPTION
## Summary
- create a simple Tooltip component
- use Tooltip in TextField, SelectField, DateField and TimeField

## Testing
- `npm test --prefix childcare-app` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a43d878848331a040e67543ce6dc5