### PR TITLE
Support nested conditional schema validation

### DIFF
--- a/childcare-app/__tests__/applicant-schema.test.ts
+++ b/childcare-app/__tests__/applicant-schema.test.ts
@@ -1,4 +1,5 @@
 import { applicantSchema } from '../schemas/applicant'
+import { buildConditionalSchema } from '../utils/schemaBuilder'
 
 describe('applicantSchema', () => {
   it('validates required fields', () => {
@@ -26,6 +27,34 @@ describe('applicantSchema', () => {
       assistance_reason_choice: ['Employment', 'Homelessness', 'Looking for Work']
     })
     expect(result.success).toBe(false)
+  })
+
+  it('validates conditional fields inside groups', () => {
+    const fields = [
+      {
+        id: 'children',
+        type: 'group',
+        metadata: { multiple: true },
+        fields: [
+          { id: 'name_ref', type: 'select' },
+          {
+            id: 'other_source_text',
+            type: 'text',
+            requiredCondition: { field: 'name_ref', operator: 'equals', value: 'Other' }
+          }
+        ]
+      }
+    ]
+
+    const schema = buildConditionalSchema(fields)
+
+    const missing = schema.safeParse({ children: [{ name_ref: 'Other' }] })
+    expect(missing.success).toBe(false)
+    if (!missing.success) {
+      expect(missing.error.issues[0].path).toEqual(['children', 0, 'other_source_text'])
+    }
+    expect(schema.safeParse({ children: [{ name_ref: 'Other', other_source_text: 'foo' }] }).success).toBe(true)
+    expect(schema.safeParse({ children: [{ name_ref: 'SelfEmployment' }] }).success).toBe(true)
   })
 
 })

--- a/childcare-app/utils/schemaBuilder.ts
+++ b/childcare-app/utils/schemaBuilder.ts
@@ -6,37 +6,41 @@ type FieldSpec = any
 export function buildSchema(fields: FieldSpec[]): ZodTypeAny {
   const shape: Record<string, ZodTypeAny> = {}
   for (const field of fields) {
-    if (field.type === 'group') continue
     let schema: ZodTypeAny
-    switch (field.type) {
-      case 'checkbox':
-        schema = z.array(z.string())
-        break
-      case 'select':
-        if (field.metadata?.multiple) {
+    if (field.type === 'group') {
+      const inner = buildSchema(field.fields || [])
+      schema = field.metadata?.multiple ? z.array(inner) : inner
+    } else {
+      switch (field.type) {
+        case 'checkbox':
           schema = z.array(z.string())
-          if (field.constraints?.minSelections) {
-            schema = schema.min(field.constraints.minSelections)
+          break
+        case 'select':
+          if (field.metadata?.multiple) {
+            schema = z.array(z.string())
+            if (field.constraints?.minSelections) {
+              schema = schema.min(field.constraints.minSelections)
+            }
+            if (field.constraints?.maxSelections) {
+              schema = schema.max(field.constraints.maxSelections)
+            }
+          } else {
+            schema = z.string()
           }
-          if (field.constraints?.maxSelections) {
-            schema = schema.max(field.constraints.maxSelections)
-          }
-        } else {
+          break
+        case 'file':
+          schema = z.any()
+          break
+        default:
           schema = z.string()
-        }
-        break
-      case 'file':
-        schema = z.any()
-        break
-      default:
-        schema = z.string()
-    }
-    if (field.required) {
-      schema = schema.refine(v => v !== undefined && v !== '', { message: 'Required' })
-    }
-    if (field.constraints?.pattern) {
-      const regex = new RegExp(field.constraints.pattern)
-      schema = schema.regex(regex, 'Invalid format')
+      }
+      if (field.required) {
+        schema = schema.refine(v => v !== undefined && v !== '', { message: 'Required' })
+      }
+      if (field.constraints?.pattern) {
+        const regex = new RegExp(field.constraints.pattern)
+        schema = schema.regex(regex, 'Invalid format')
+      }
     }
     shape[field.id] = schema
   }
@@ -45,14 +49,32 @@ export function buildSchema(fields: FieldSpec[]): ZodTypeAny {
 
 export function buildConditionalSchema(fields: FieldSpec[]) {
   const base = buildSchema(fields)
-  return base.superRefine((data, ctx) => {
-    for (const field of fields) {
-      if (field.requiredCondition) {
-        const cond = field.requiredCondition as Condition
-        if (evaluateCondition(cond, data) && (data[field.id] === undefined || data[field.id] === '')) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Required', path: [field.id] })
+
+  function applyConditions(fs: FieldSpec[], obj: any, path: (string | number)[], ctx: any) {
+    for (const f of fs) {
+      const currentPath = [...path, f.id]
+      if (f.type === 'group') {
+        const groupData = obj[f.id]
+        if (f.metadata?.multiple && Array.isArray(groupData)) {
+          groupData.forEach((item: any, idx: number) => {
+            applyConditions(f.fields || [], item ?? {}, [...currentPath, idx], ctx)
+          })
+        } else if (!f.metadata?.multiple && groupData) {
+          applyConditions(f.fields || [], groupData, currentPath, ctx)
+        }
+        continue
+      }
+
+      if (f.requiredCondition) {
+        const cond = f.requiredCondition as Condition
+        if (evaluateCondition(cond, obj) && (obj[f.id] === undefined || obj[f.id] === '')) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Required', path: currentPath })
         }
       }
     }
+  }
+
+  return base.superRefine((data, ctx) => {
+    applyConditions(fields, data, [], ctx)
   })
 }


### PR DESCRIPTION
## Summary
- handle group fields recursively when building schemas
- apply conditional validations for nested group fields
- test conditional validation for groups

## Testing
- `npm test --prefix childcare-app` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a44a5039c8331bdd1e93015947c44