### PR TITLE
Add collapsible info blocks

### DIFF
--- a/childcare-app/components/FormRenderer.tsx
+++ b/childcare-app/components/FormRenderer.tsx
@@ -99,7 +99,15 @@ export default function FormRenderer() {
           />
         )
       case 'info':
-        return <InfoBlock key={f.id} title={f.title || ''} content={f.content || ''} />
+        return (
+          <InfoBlock
+            key={f.id}
+            title={f.title || ''}
+            content={f.content || ''}
+            collapsible={f.ui?.collapsible}
+            defaultCollapsed={f.ui?.defaultCollapsed}
+          />
+        )
       case 'group':
         return <GroupField key={f.id} field={f} renderField={renderField} />
       default:
@@ -117,7 +125,12 @@ export default function FormRenderer() {
             {currentStep.sections?.map(sec => (
               <div key={sec.id}>
                 {sec.type === 'info' ? (
-                  <InfoBlock title={sec.title || ''} content={sec.content || ''} />
+                  <InfoBlock
+                    title={sec.title || ''}
+                    content={sec.content || ''}
+                    collapsible={sec.ui?.collapsible}
+                    defaultCollapsed={sec.ui?.defaultCollapsed}
+                  />
                 ) : (
                   sec.fields?.map(renderField)
                 )}

--- a/childcare-app/components/fields/InfoBlock.tsx
+++ b/childcare-app/components/fields/InfoBlock.tsx
@@ -1,15 +1,27 @@
+import React, { useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 
 interface Props {
   title: string
   content: string
+  collapsible?: boolean
+  defaultCollapsed?: boolean
 }
 
-export default function InfoBlock({ title, content }: Props) {
+export default function InfoBlock({ title, content, collapsible, defaultCollapsed }: Props) {
+  const [collapsed, setCollapsed] = useState<boolean>(defaultCollapsed ?? false)
+
   return (
     <div className="mb-6 p-4 bg-blue-50 border-l-4 border-blue-400">
-      <h3 className="font-semibold mb-2">{title}</h3>
-      <ReactMarkdown>{content}</ReactMarkdown>
+      <div className="flex items-center justify-between cursor-pointer" onClick={() => collapsible && setCollapsed(c => !c)}>
+        <h3 className="font-semibold mb-2">{title}</h3>
+        {collapsible && (
+          <button type="button" className="text-sm underline">
+            {collapsed ? 'Show' : 'Hide'}
+          </button>
+        )}
+      </div>
+      {(!collapsible || !collapsed) && <ReactMarkdown>{content}</ReactMarkdown>}
     </div>
   )
 }

--- a/childcare-app/types/field.ts
+++ b/childcare-app/types/field.ts
@@ -6,7 +6,7 @@ export interface FieldSpec {
   required?: boolean
   requiredCondition?: any
   visibilityCondition?: any
-  ui?: { options?: any }
+  ui?: { options?: any; collapsible?: boolean; defaultCollapsed?: boolean }
   placeholder?: string
   content?: string
   metadata?: { multiple?: boolean; proofCategory?: string }


### PR DESCRIPTION
## Summary
- extend InfoBlock component to support collapsible content
- pass collapsible options from form spec
- update field types

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a4c9462dc83319459d057361cd94a