### PR TITLE
Make stepper position configurable

### DIFF
--- a/childcare-app/components/FormRenderer.tsx
+++ b/childcare-app/components/FormRenderer.tsx
@@ -19,6 +19,7 @@ import { FieldSpec } from '../types/field'
 
 export default function FormRenderer() {
   const steps = formSpec.form.steps
+  const stepperPosition: 'left' | 'right' = (formSpec.form.layout?.stepperPosition as any) || 'right'
   const [stepIndex, setStepIndex] = useState(0)
   const stepFields = steps[stepIndex].sections?.flatMap((sec: any) => sec.fields || []) || []
   const schema = buildConditionalSchema(stepFields)
@@ -118,7 +119,7 @@ export default function FormRenderer() {
 
 
   return (
-    <div className="flex">
+    <div className={`flex ${stepperPosition === 'left' ? 'flex-row-reverse' : ''}`}>
       <div className="flex-1 p-4">
         <h2 className="text-lg font-bold mb-4">{currentStep.title}</h2>
         <FormProvider {...methods}>
@@ -148,7 +149,15 @@ export default function FormRenderer() {
           </form>
         </FormProvider>
       </div>
-      <Stepper steps={steps.map(s => ({ id: s.id, title: s.title }))} current={stepIndex} onStepClick={i => { saveDraft(); setStepIndex(i) }} />
+      <Stepper
+        steps={steps.map(s => ({ id: s.id, title: s.title }))}
+        current={stepIndex}
+        onStepClick={i => {
+          saveDraft()
+          setStepIndex(i)
+        }}
+        position={stepperPosition}
+      />
     </div>
   )
 }

--- a/childcare-app/features/Stepper.tsx
+++ b/childcare-app/features/Stepper.tsx
@@ -1,11 +1,13 @@
 interface Props {
-  steps: { id: string; title: string }[];
-  current: number;
-  onStepClick: (index: number) => void;
+  steps: { id: string; title: string }[]
+  current: number
+  onStepClick: (index: number) => void
+  position?: 'left' | 'right'
 }
-export default function Stepper({ steps, current, onStepClick }: Props) {
+export default function Stepper({ steps, current, onStepClick, position = 'right' }: Props) {
+  const marginClass = position === 'left' ? 'mr-8' : 'ml-8'
   return (
-    <nav className="w-64 ml-8">
+    <nav className={`w-64 ${marginClass}`}>
       <ol className="space-y-2 bg-white p-4 rounded-2xl shadow-md">
         {steps.map((s, i) => (
           <li key={s.id}>


### PR DESCRIPTION
## Summary
- allow FormRenderer to read `layout.stepperPosition`
- update Stepper to accept a `position` prop and adjust margin
- swap layout order when the stepper is on the left

## Testing
- `npm --prefix childcare-app test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a4e2b9b548331a03199ce16af5565