### PR TITLE
Map uploaded files to DocumentList

### DIFF
--- a/childcare-app/__tests__/formMapper.test.ts
+++ b/childcare-app/__tests__/formMapper.test.ts
@@ -1,0 +1,23 @@
+import { mapToSubmission } from '../utils/formMapper'
+
+// jsdom provides a File constructor
+
+describe('mapToSubmission', () => {
+  it('maps uploaded files to DocumentList entries', () => {
+    const file = new File(['dummy'], 'proof.pdf', { type: 'application/pdf' })
+    const result = mapToSubmission({
+      applicant_first_name: 'A',
+      applicant_last_name: 'B',
+      applicant_date_of_birth: '2000-01-01',
+      marital_status: 'Single',
+      income_proof: [file]
+    })
+    expect(result.DocumentList.length).toBe(1)
+    expect(result.DocumentList[0]).toEqual({
+      proofCategory: 'Income Verification',
+      name: 'proof.pdf',
+      fileType: 'application/pdf',
+      fileSize: file.size
+    })
+  })
+})

--- a/childcare-app/types/openapi.d.ts
+++ b/childcare-app/types/openapi.d.ts
@@ -6,5 +6,12 @@ export interface ApplicationSubmission {
     MaritalStatus: 'Single' | 'Married' | 'Divorced' | 'Widowed' | 'Separated'
   }
   ChildrenNeedingCare: any[]
-  DocumentList: any[]
+  DocumentList: DocumentListEntry[]
+}
+
+export interface DocumentListEntry {
+  proofCategory: string
+  name: string
+  fileType: string
+  fileSize: number
 }

--- a/childcare-app/utils/formMapper.ts
+++ b/childcare-app/utils/formMapper.ts
@@ -1,6 +1,45 @@
-import { ApplicationSubmission } from '../types/openapi'
+import { ApplicationSubmission, DocumentListEntry } from '../types/openapi'
+
+interface FileFieldConfig {
+  proofCategory: string
+  multiple: boolean
+}
+
+const FILE_FIELD_CONFIG: Record<string, FileFieldConfig> = {
+  income_proof: { proofCategory: 'Income Verification', multiple: true },
+  nyc_residency_file: { proofCategory: 'NYC Residency', multiple: false },
+  citizenship_doc_file: { proofCategory: 'Citizenship/Immigration Status', multiple: false },
+  relationship_doc_file: { proofCategory: 'Child Relationship', multiple: false },
+  age_doc_file: { proofCategory: 'Child Age', multiple: false }
+}
 
 export function mapToSubmission(formData: Record<string, any>): ApplicationSubmission {
+  const docs: DocumentListEntry[] = []
+  for (const [fieldId, config] of Object.entries(FILE_FIELD_CONFIG)) {
+    const value = formData[fieldId]
+    if (!value) continue
+
+    const files: File[] = []
+    if (value instanceof FileList) {
+      files.push(...Array.from(value))
+    } else if (Array.isArray(value)) {
+      for (const f of value) {
+        if (f instanceof File) files.push(f)
+      }
+    } else if (value instanceof File) {
+      files.push(value)
+    }
+
+    for (const file of files) {
+      docs.push({
+        proofCategory: config.proofCategory,
+        name: file.name,
+        fileType: file.type,
+        fileSize: file.size,
+      })
+    }
+  }
+
   return {
     Applicant: {
       FirstName: formData.applicant_first_name,
@@ -9,6 +48,6 @@ export function mapToSubmission(formData: Record<string, any>): ApplicationSubmi
       MaritalStatus: formData.marital_status,
     },
     ChildrenNeedingCare: [],
-    DocumentList: [],
+    DocumentList: docs,
   }
 }


### PR DESCRIPTION
## Summary
- expand `ApplicationSubmission` types with new `DocumentListEntry`
- enhance `formMapper` to build `DocumentList` from uploaded file fields
- add unit test for `mapToSubmission`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a4ecbc3308331952e98fef27803c4