### PR TITLE
Expand mapToSubmission

### DIFF
--- a/childcare-app/__tests__/formMapper.test.ts
+++ b/childcare-app/__tests__/formMapper.test.ts
@@ -20,4 +20,98 @@ describe('mapToSubmission', () => {
       fileSize: file.size
     })
   })
+
+  it('maps children, family members and income information', () => {
+    const result = mapToSubmission({
+      applicant_first_name: 'A',
+      applicant_last_name: 'B',
+      applicant_date_of_birth: '2000-01-01',
+      marital_status: 'Married',
+      children: [
+        {
+          child_first_name: 'Kid',
+          child_last_name: 'One',
+          child_mi: 'Q',
+          child_relationship_to_applicant: 'Child',
+          child_date_of_birth: '2020-01-01',
+          child_sex: 'Male',
+          child_ethnicity: 'Hispanic',
+          child_race: ['AI'],
+          child_ssn: '123-45-6789',
+          do_both_parents_reside_in_home: 'Yes',
+          has_disability: 'No',
+          is_immigration_status_satisfactory: 'Yes',
+        },
+      ],
+      familymember: [
+        {
+          family_member_first_name: 'Jane',
+          family_member_last_name: 'Doe',
+          family_member_mi: 'X',
+          family_member_relationship_to_applicant: 'Spouse',
+          family_member_date_of_birth: '1990-01-01',
+          family_member_sex: 'Female',
+          family_member_ethnicity: 'No',
+          family_member_race: ['WH'],
+          family_member_ssn: '987-65-4321',
+        },
+      ],
+      income_source_entries: [
+        {
+          name_ref: 'ApplicantWages',
+          other_source_text: null,
+          is_source_applicable: 'Yes',
+          gross_amount: 100,
+          how_often: 'Weekly',
+          recipient: 'Self',
+          monthly_amount: 400,
+        },
+      ],
+      total_income_value: 400,
+    })
+
+    expect(result.ChildrenNeedingCare).toEqual([
+      {
+        FirstName: 'Kid',
+        LastName: 'One',
+        MI: 'Q',
+        RelationshipToApplicant: 'Child',
+        DateOfBirth: '2020-01-01',
+        Sex: 'Male',
+        Ethnicity: 'Hispanic',
+        Race: ['AI'],
+        SSN: '123-45-6789',
+        DoBothParentsResideInHome: 'Yes',
+        HasDisability: 'No',
+        IsImmigrationStatusSatisfactory: 'Yes',
+      },
+    ])
+    expect(result.FamilyMembers).toEqual([
+      {
+        FirstName: 'Jane',
+        LastName: 'Doe',
+        MI: 'X',
+        RelationshipToApplicant: 'Spouse',
+        DateOfBirth: '1990-01-01',
+        Sex: 'Female',
+        Ethnicity: 'No',
+        Race: ['WH'],
+        SSN: '987-65-4321',
+      },
+    ])
+    expect(result.IncomeInformation).toEqual({
+      Sources: [
+        {
+          NameRef: 'ApplicantWages',
+          OtherSourceText: null,
+          IsSourceApplicable: 'Yes',
+          GrossAmount: 100,
+          HowOften: 'Weekly',
+          Recipient: 'Self',
+          MonthlyAmount: 400,
+        },
+      ],
+      TotalIncome: 400,
+    })
+  })
 })

--- a/childcare-app/types/openapi.d.ts
+++ b/childcare-app/types/openapi.d.ts
@@ -1,3 +1,70 @@
+export type YesNo = 'Yes' | 'No'
+export type Sex = 'Male' | 'Female' | 'X'
+export type Ethnicity = 'Hispanic' | 'Latino' | 'No' | 'Prefer not to answer'
+export type Race = 'AI' | 'AS' | 'BL' | 'HP' | 'WH'
+
+export type ChildRelationship = 'Child' | 'Grandchild' | 'Foster Child' | 'Other'
+export type FamilyRelationship =
+  | 'Spouse'
+  | 'Partner'
+  | 'Foster Parent'
+  | 'Child'
+  | 'Other'
+
+export type IncomeSourceName =
+  | 'ApplicantWages'
+  | 'SecondParentWages'
+  | 'SelfEmployment'
+  | 'ChildSupport'
+  | 'Alimony'
+  | 'Unemployment'
+  | 'SocialSecurity'
+  | 'Disability'
+  | 'Rental'
+  | 'Dividends'
+  | 'Retirement'
+  | 'CashAssistance'
+  | 'Other'
+
+export type IncomeFrequency = 'Weekly' | 'Bi-weekly' | 'Monthly' | 'Other'
+
+export interface Child {
+  LastName: string
+  FirstName: string
+  MI?: string | null
+  RelationshipToApplicant: ChildRelationship
+  DateOfBirth: string
+  Sex: Sex
+  Ethnicity?: Ethnicity
+  Race?: Race[]
+  SSN?: string
+  DoBothParentsResideInHome: YesNo
+  HasDisability: YesNo
+  IsImmigrationStatusSatisfactory: YesNo
+}
+
+export interface FamilyMember {
+  LastName: string
+  FirstName: string
+  MI?: string | null
+  RelationshipToApplicant: FamilyRelationship
+  DateOfBirth: string
+  Sex: 'Male' | 'Female'
+  Ethnicity?: Ethnicity
+  Race?: Race[]
+  SSN?: string
+}
+
+export interface IncomeSource {
+  NameRef: IncomeSourceName
+  OtherSourceText?: string | null
+  IsSourceApplicable: YesNo
+  GrossAmount: number
+  HowOften: IncomeFrequency
+  Recipient: string
+  MonthlyAmount: number
+}
+
 export interface ApplicationSubmission {
   Applicant: {
     FirstName: string
@@ -5,7 +72,12 @@ export interface ApplicationSubmission {
     DateOfBirth: string
     MaritalStatus: 'Single' | 'Married' | 'Divorced' | 'Widowed' | 'Separated'
   }
-  ChildrenNeedingCare: any[]
+  ChildrenNeedingCare: Child[]
+  FamilyMembers: FamilyMember[]
+  IncomeInformation?: {
+    Sources: IncomeSource[]
+    TotalIncome: number
+  }
   DocumentList: DocumentListEntry[]
 }
 

--- a/childcare-app/utils/formMapper.ts
+++ b/childcare-app/utils/formMapper.ts
@@ -1,4 +1,10 @@
-import { ApplicationSubmission, DocumentListEntry } from '../types/openapi'
+import {
+  ApplicationSubmission,
+  DocumentListEntry,
+  Child,
+  FamilyMember,
+  IncomeSource,
+} from '../types/openapi'
 
 interface FileFieldConfig {
   proofCategory: string
@@ -40,14 +46,76 @@ export function mapToSubmission(formData: Record<string, any>): ApplicationSubmi
     }
   }
 
-  return {
+  const children: Child[] = []
+  if (Array.isArray(formData.children)) {
+    for (const c of formData.children) {
+      children.push({
+        FirstName: c.child_first_name,
+        LastName: c.child_last_name,
+        MI: c.child_mi ?? null,
+        RelationshipToApplicant: c.child_relationship_to_applicant,
+        DateOfBirth: c.child_date_of_birth,
+        Sex: c.child_sex,
+        Ethnicity: c.child_ethnicity,
+        Race: c.child_race,
+        SSN: c.child_ssn,
+        DoBothParentsResideInHome: c.do_both_parents_reside_in_home,
+        HasDisability: c.has_disability,
+        IsImmigrationStatusSatisfactory: c.is_immigration_status_satisfactory,
+      })
+    }
+  }
+
+  const familyMembers: FamilyMember[] = []
+  if (Array.isArray(formData.familymember)) {
+    for (const m of formData.familymember) {
+      familyMembers.push({
+        FirstName: m.family_member_first_name,
+        LastName: m.family_member_last_name,
+        MI: m.family_member_mi ?? null,
+        RelationshipToApplicant: m.family_member_relationship_to_applicant,
+        DateOfBirth: m.family_member_date_of_birth,
+        Sex: m.family_member_sex,
+        Ethnicity: m.family_member_ethnicity,
+        Race: m.family_member_race,
+        SSN: m.family_member_ssn,
+      })
+    }
+  }
+
+  const incomeSources: IncomeSource[] = []
+  if (Array.isArray(formData.income_source_entries)) {
+    for (const src of formData.income_source_entries) {
+      incomeSources.push({
+        NameRef: src.name_ref,
+        OtherSourceText: src.other_source_text ?? null,
+        IsSourceApplicable: src.is_source_applicable,
+        GrossAmount: src.gross_amount,
+        HowOften: src.how_often,
+        Recipient: src.recipient,
+        MonthlyAmount: src.monthly_amount,
+      })
+    }
+  }
+
+  const submission: ApplicationSubmission = {
     Applicant: {
       FirstName: formData.applicant_first_name,
       LastName: formData.applicant_last_name,
       DateOfBirth: formData.applicant_date_of_birth,
       MaritalStatus: formData.marital_status,
     },
-    ChildrenNeedingCare: [],
+    ChildrenNeedingCare: children,
+    FamilyMembers: familyMembers,
     DocumentList: docs,
   }
+
+  if (incomeSources.length || formData.total_income_value !== undefined) {
+    submission.IncomeInformation = {
+      Sources: incomeSources,
+      TotalIncome: formData.total_income_value,
+    }
+  }
+
+  return submission
 }


### PR DESCRIPTION
## Summary
- extend OpenAPI type definitions with children, family member, and income source models
- map children, family members and income sources in `mapToSubmission`
- test the expanded mapping logic

## Testing
- `npm test --prefix childcare-app` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a4fddbc2883319a29466f0150e514