### PR TITLE
Enhance accessibility of stepper & tooltips

### DIFF
--- a/childcare-app/components/fields/Tooltip.tsx
+++ b/childcare-app/components/fields/Tooltip.tsx
@@ -14,10 +14,15 @@ export default function Tooltip({ content, children }: TooltipProps) {
       onMouseLeave={() => setOpen(false)}
       onFocus={() => setOpen(true)}
       onBlur={() => setOpen(false)}
+      tabIndex={0}
+      aria-label={content}
     >
       {children}
       {open && (
-        <span className="absolute left-1/2 -translate-x-1/2 mt-1 whitespace-nowrap bg-black text-white text-xs rounded py-1 px-2 z-10">
+        <span
+          role="tooltip"
+          className="absolute left-1/2 -translate-x-1/2 mt-1 whitespace-nowrap bg-black text-white text-xs rounded py-1 px-2 z-10"
+        >
           {content}
         </span>
       )}

--- a/childcare-app/features/Stepper.tsx
+++ b/childcare-app/features/Stepper.tsx
@@ -7,13 +7,15 @@ interface Props {
 export default function Stepper({ steps, current, onStepClick, position = 'right' }: Props) {
   const marginClass = position === 'left' ? 'mr-8' : 'ml-8'
   return (
-    <nav className={`w-64 ${marginClass}`}>
-      <ol className="space-y-2 bg-white p-4 rounded-2xl shadow-md">
+    <nav className={`w-64 ${marginClass}`} role="navigation" aria-label="Form steps">
+      <ol className="space-y-2 bg-white p-4 rounded-2xl shadow-md" role="list">
         {steps.map((s, i) => (
-          <li key={s.id}>
+          <li key={s.id} role="listitem">
             <button
               className={`w-full text-left p-2 rounded-lg ${current === i ? 'bg-blue-600 text-white' : 'bg-gray-100'}`}
               onClick={() => onStepClick(i)}
+              aria-label={s.title}
+              aria-current={current === i ? 'step' : undefined}
             >
               {s.title}
             </button>


### PR DESCRIPTION
## Summary
- add accessible roles and aria labels to stepper
- improve tooltip semantics with role and label

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a51550f9883319c9b71fe683f00f9