### PR TITLE
Integrate CSS design tokens

### DIFF
--- a/childcare-app/components/FormRenderer.tsx
+++ b/childcare-app/components/FormRenderer.tsx
@@ -125,7 +125,10 @@ export default function FormRenderer() {
         <FormProvider {...methods}>
           <form onSubmit={onSubmit} className="space-y-4">
             {currentStep.sections?.map(sec => (
-              <div key={sec.id}>
+              <section key={sec.id} className="form-section p-4">
+                {sec.title && (
+                  <header className="form-section-header">{sec.title}</header>
+                )}
                 {sec.type === 'info' ? (
                   <InfoBlock
                     title={sec.title || ''}
@@ -136,14 +139,14 @@ export default function FormRenderer() {
                 ) : (
                   sec.fields?.map(renderField)
                 )}
-              </div>
+              </section>
             ))}
             <div className="flex justify-between">
-              <button type="button" disabled={stepIndex === 0} onClick={goPrev} className="px-4 py-2 bg-gray-300 rounded">Back</button>
+              <button type="button" disabled={stepIndex === 0} onClick={goPrev} className="button-secondary">Back</button>
               {stepIndex < steps.length - 1 ? (
-                <button type="button" onClick={goNext} className="px-4 py-2 bg-blue-600 text-white rounded">Next</button>
+                <button type="button" onClick={goNext} className="button-primary">Next</button>
               ) : (
-                <button type="submit" className="px-4 py-2 bg-green-600 text-white rounded">Submit</button>
+                <button type="submit" className="button-primary">Submit</button>
               )}
             </div>
           </form>

--- a/childcare-app/components/GroupField.tsx
+++ b/childcare-app/components/GroupField.tsx
@@ -12,7 +12,7 @@ export default function GroupField({ field, renderField }: Props) {
   const { fields, append, remove } = useFieldArray({ control, name: field.id })
 
   return (
-    <div className="mb-6 border p-2">
+    <div className="form-group-wrapper">
       <h3 className="font-semibold mb-2">{field.label}</h3>
       {fields.map((item, index) => (
         <div key={item.id} className="mb-4">
@@ -20,10 +20,10 @@ export default function GroupField({ field, renderField }: Props) {
             const childId = `${field.id}.${index}.${child.id}`
             return renderField({ ...child, id: childId })
           })}
-          <button type="button" className="text-sm text-red-600" onClick={() => remove(index)}>Remove</button>
+          <button type="button" className="button-secondary text-sm" onClick={() => remove(index)}>Remove</button>
         </div>
       ))}
-      <button type="button" className="text-sm text-blue-600" onClick={() => append({})}>Add</button>
+      <button type="button" className="button-primary text-sm" onClick={() => append({})}>Add</button>
     </div>
   )
 }

--- a/childcare-app/components/fields/CheckboxGroup.tsx
+++ b/childcare-app/components/fields/CheckboxGroup.tsx
@@ -15,7 +15,7 @@ export default function CheckboxGroup({ id, label, options, required }: Props) {
   return (
     <fieldset className="mb-4">
       <legend className="font-medium">
-        {label} {required && <span className="text-red-600">*</span>}
+        {label} {required && <span className="required-asterisk">*</span>}
       </legend>
       {options.map(opt => (
         <label key={opt.value} className="block">
@@ -24,7 +24,7 @@ export default function CheckboxGroup({ id, label, options, required }: Props) {
         </label>
       ))}
       {errors[id] && (
-        <p className="text-red-600 text-sm">This field is required.</p>
+        <p className="form-error-alert">This field is required.</p>
       )}
     </fieldset>
   )

--- a/childcare-app/components/fields/DateField.tsx
+++ b/childcare-app/components/fields/DateField.tsx
@@ -12,17 +12,17 @@ export default function DateField({ id, label, required, tooltip }: Props) {
   return (
     <div className="mb-4">
       <label htmlFor={id} className="block font-medium">
-        {label} {required && <span className="text-red-600">*</span>}
+        {label} {required && <span className="required-asterisk">*</span>}
       </label>
       {tooltip ? (
         <Tooltip content={tooltip}>
-          <input id={id} type="date" title={tooltip} {...register(id, { required })} className="border rounded p-2 w-full" />
+          <input id={id} type="date" title={tooltip} {...register(id, { required })} className="w-full" />
         </Tooltip>
       ) : (
-        <input id={id} type="date" title={tooltip} {...register(id, { required })} className="border rounded p-2 w-full" />
+        <input id={id} type="date" title={tooltip} {...register(id, { required })} className="w-full" />
       )}
       {errors[id] && (
-        <p className="text-red-600 text-sm">This field is required.</p>
+        <p className="form-error-alert">This field is required.</p>
       )}
     </div>
   )

--- a/childcare-app/components/fields/FileUploadField.tsx
+++ b/childcare-app/components/fields/FileUploadField.tsx
@@ -17,7 +17,7 @@ export default function FileUploadField({ id, label, required, multiple, accept,
   return (
     <div className="mb-4">
       <label htmlFor={id} className="block font-medium">
-        {label} {required && <span className="text-red-600">*</span>}
+        {label} {required && <span className="required-asterisk">*</span>}
       </label>
       <input
         id={id}
@@ -67,7 +67,7 @@ export default function FileUploadField({ id, label, required, multiple, accept,
         className="block"
       />
       {errors[id] && (
-        <p className="text-red-600 text-sm">{errors[id].message as string}</p>
+        <p className="form-error-alert">{errors[id].message as string}</p>
       )}
     </div>
   )

--- a/childcare-app/components/fields/RadioGroup.tsx
+++ b/childcare-app/components/fields/RadioGroup.tsx
@@ -10,7 +10,7 @@ export default function RadioGroup({ id, label, options, required }: Props) {
   return (
     <fieldset className="mb-4">
       <legend className="font-medium">
-        {label} {required && <span className="text-red-600">*</span>}
+        {label} {required && <span className="required-asterisk">*</span>}
       </legend>
       {options.map(opt => (
         <label key={opt} className="block">
@@ -19,7 +19,7 @@ export default function RadioGroup({ id, label, options, required }: Props) {
         </label>
       ))}
       {errors[id] && (
-        <p className="text-red-600 text-sm">This field is required.</p>
+        <p className="form-error-alert">This field is required.</p>
       )}
     </fieldset>
   )

--- a/childcare-app/components/fields/SelectField.tsx
+++ b/childcare-app/components/fields/SelectField.tsx
@@ -14,7 +14,7 @@ export default function SelectField({ id, label, options, required, multiple, to
   return (
     <div className="mb-4">
       <label htmlFor={id} className="block font-medium">
-        {label} {required && <span className="text-red-600">*</span>}
+        {label} {required && <span className="required-asterisk">*</span>}
       </label>
       {tooltip ? (
         <Tooltip content={tooltip}>
@@ -31,7 +31,7 @@ export default function SelectField({ id, label, options, required, multiple, to
                 }
               }
             })}
-            className="border rounded p-2 w-full"
+            className="w-full"
           >
             {!multiple && <option value="">Select...</option>}
 
@@ -51,7 +51,7 @@ export default function SelectField({ id, label, options, required, multiple, to
               setValue(id, vals)
             }
           } })}
-          className="border rounded p-2 w-full"
+          className="w-full"
         >
           {!multiple && <option value="">Select...</option>}
 
@@ -61,7 +61,7 @@ export default function SelectField({ id, label, options, required, multiple, to
         </select>
       )}
       {errors[id] && (
-        <p className="text-red-600 text-sm">This field is required.</p>
+        <p className="form-error-alert">This field is required.</p>
       )}
     </div>
   )

--- a/childcare-app/components/fields/TextField.tsx
+++ b/childcare-app/components/fields/TextField.tsx
@@ -25,7 +25,7 @@ export default function TextField({ id, label, type = 'text', required, placehol
   return (
     <div className="mb-4">
       <label htmlFor={id} className="block font-medium">
-        {label} {required && <span className="text-red-600">*</span>}
+        {label} {required && <span className="required-asterisk">*</span>}
       </label>
       {tooltip ? (
         <Tooltip content={tooltip}>
@@ -35,7 +35,7 @@ export default function TextField({ id, label, type = 'text', required, placehol
             title={tooltip}
             {...register(id, validation)}
             placeholder={placeholder}
-            className="border rounded p-2 w-full"
+            className="w-full"
           />
         </Tooltip>
       ) : (
@@ -45,11 +45,11 @@ export default function TextField({ id, label, type = 'text', required, placehol
           title={tooltip}
           {...register(id, validation)}
           placeholder={placeholder}
-          className="border rounded p-2 w-full"
+          className="w-full"
         />
       )}
       {errors[id] && (
-        <p className="text-red-600 text-sm">This field is required.</p>
+        <p className="form-error-alert">This field is required.</p>
       )}
     </div>
   )

--- a/childcare-app/components/fields/TimeField.tsx
+++ b/childcare-app/components/fields/TimeField.tsx
@@ -12,18 +12,18 @@ export default function TimeField({ id, label, required, tooltip }: Props) {
   return (
     <div className="mb-4">
       <label htmlFor={id} className="block font-medium">
-        {label} {required && <span className="text-red-600">*</span>}
+        {label} {required && <span className="required-asterisk">*</span>}
       </label>
       {tooltip ? (
         <Tooltip content={tooltip}>
-          <input id={id} type="time" title={tooltip} {...register(id, { required })} className="border rounded p-2 w-full" />
+          <input id={id} type="time" title={tooltip} {...register(id, { required })} className="w-full" />
         </Tooltip>
       ) : (
-        <input id={id} type="time" title={tooltip} {...register(id, { required })} className="border rounded p-2 w-full" />
+        <input id={id} type="time" title={tooltip} {...register(id, { required })} className="w-full" />
       )}
 
       {errors[id] && (
-        <p className="text-red-600 text-sm">This field is required.</p>
+        <p className="form-error-alert">This field is required.</p>
       )}
     </div>
   )

--- a/childcare-app/features/Stepper.tsx
+++ b/childcare-app/features/Stepper.tsx
@@ -8,11 +8,19 @@ export default function Stepper({ steps, current, onStepClick, position = 'right
   const marginClass = position === 'left' ? 'mr-8' : 'ml-8'
   return (
     <nav className={`w-64 ${marginClass}`} role="navigation" aria-label="Form steps">
-      <ol className="space-y-2 bg-white p-4 rounded-2xl shadow-md" role="list">
+      <ol
+        className="space-y-2 p-4 rounded-2xl shadow-md"
+        style={{ backgroundColor: 'var(--surface)' }}
+        role="list"
+      >
         {steps.map((s, i) => (
           <li key={s.id} role="listitem">
             <button
-              className={`w-full text-left p-2 rounded-lg ${current === i ? 'bg-blue-600 text-white' : 'bg-gray-100'}`}
+              className="w-full text-left p-2 rounded-lg"
+              style={{
+                backgroundColor: current === i ? 'var(--primary-color)' : 'var(--secondary-color)',
+                color: current === i ? '#ffffff' : 'var(--font-color)',
+              }}
               onClick={() => onStepClick(i)}
               aria-label={s.title}
               aria-current={current === i ? 'step' : undefined}

--- a/childcare-app/pages/_app.tsx
+++ b/childcare-app/pages/_app.tsx
@@ -2,5 +2,9 @@ import type { AppProps } from 'next/app'
 import '../styles/globals.css'
 
 export default function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return (
+    <main className="form-main">
+      <Component {...pageProps} />
+    </main>
+  )
 }

--- a/childcare-app/pages/_document.tsx
+++ b/childcare-app/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html>
+      <Head />
+      <body className="font-sans text-base bg-[var(--background)] text-[var(--font-color)]">
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}

--- a/childcare-app/pages/application.tsx
+++ b/childcare-app/pages/application.tsx
@@ -2,9 +2,5 @@ import dynamic from 'next/dynamic'
 const FormRenderer = dynamic(() => import('../components/FormRenderer'), { ssr: false })
 
 export default function Application() {
-  return (
-    <main className="p-4">
-      <FormRenderer />
-    </main>
-  )
+  return <FormRenderer />
 }

--- a/childcare-app/pages/index.tsx
+++ b/childcare-app/pages/index.tsx
@@ -4,7 +4,7 @@ export default function Home() {
   return (
     <div className="p-8">
       <h1 className="text-xl font-bold mb-4">Childcare Voucher Application</h1>
-      <Link href="/application" className="text-blue-600 underline">
+      <Link href="/application" className="button-primary inline-block">
         Start Application
       </Link>
     </div>

--- a/childcare-app/styles/design-tokens.css
+++ b/childcare-app/styles/design-tokens.css
@@ -1,0 +1,46 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
+
+:root {
+  /* Brand & Accent Colors */
+  --primary-color: #cc4466;
+  --primary-hover: #b33a59;
+  --accent-color: #e65c7a; /* optional lighter tone */
+  --focus-ring: 0 0 0 3px rgba(204, 68, 102, 0.4);
+  --secondary-color: #F2F4F7;         /* Light gray background for sections/cards */
+  --error-color: #D93025;
+  --success-color: #34A853;
+  --warning-color: #FBBC05;
+
+
+  /* Background & Surface */
+  --background: #ffffff;
+  --surface: #ffffff;
+  --surface-alt: #f9fafb;
+  --border: #e0e0e0;
+  --shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+
+  /* Typography */
+  --font-family: 'Rubik', 'Segoe UI', 'Helvetica Neue', sans-serif;
+  --font-display: 'Rubik', sans-serif;
+  --font-size: 20px;
+  --font-size-sm: 0.9rem;
+  --font-size-lg: 1.2rem;
+  --font-color: rgba(0, 0, 0, 0.87); /* High contrast default text */
+  --font-muted: #6B7280;
+
+  /* Radius */
+  --radius: 8px;
+  --radius-sm: 4px;
+  --radius-lg: 12px;
+
+  /* Spacing (rem) */
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+
+  /* Focus Ring */
+  --focus-ring: 0 0 0 3px rgba(10, 102, 194, 0.4);
+}
+

--- a/childcare-app/styles/form.css
+++ b/childcare-app/styles/form.css
@@ -1,0 +1,502 @@
+
+@import "./design-tokens.css";
+
+body, html, #root {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  font-family: var(--font-family);
+  font-size: var(--font-size);
+  color: var(--font-color);
+  line-height: 1.5;
+  background-color: var(--background);
+}
+
+form {
+  font-family: var(--font-family);
+  font-size: var(--font-size);
+  color: var(--font-color);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5 {
+  font-family: var(--font-display), var(--font-family);
+  /* color: var(--primary-color); */
+}
+
+/* Layout */
+.wizard-layout-row {
+  display: flex;
+  min-height: 100vh;
+  overflow: hidden;
+}
+.wizard-layout-column {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+
+
+/* Main Form Area */
+.form-main {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-xl);
+  background: var(--background);
+}
+
+
+/* Header & Footer */
+.form-header,
+.form-footer {
+  padding: var(--space-md) var(--space-xl);
+  background-color: var(--surface);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: relative;
+}
+
+.form-footer {
+  border-top: 1px solid var(--border);
+  bottom: 0;
+  z-index: 20;
+  background: var(--surface);
+}
+
+.form-header .right a,
+.form-footer a {
+  margin-left: var(--space-md);
+  text-decoration: none;
+  color: var(--primary-color);
+  font-weight: 500;
+}
+
+/* Header Left with Hamburger */
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.hamburger {
+  display: none;
+  font-size: 1.5rem;
+  background: none;
+  border: none;
+  color: #111827;
+  cursor: pointer;
+  padding: var(--space-xs) var(--space-sm);
+}
+
+.hamburger:hover,
+.hamburger:focus {
+  background-color: #e5e7eb;
+  border-radius: 4px;
+}
+
+
+/* Sections */
+.form-section {
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin-bottom: var(--space-xl);
+}
+
+.form-section-header {
+  padding: 0rem; /* overridden */
+  margin: 0px;
+  background-color: var(--background);
+  border-bottom: 1px solid var(--border);
+  font-style: inherit;
+  font-variant: inherit;
+  font-stretch: inherit;
+  font-family: inherit;
+  font-optical-sizing: inherit;
+  font-size-adjust: inherit;
+  font-kerning: inherit;
+  font-feature-settings: inherit;
+  font-variation-settings: inherit;
+  color: #3b3b3b !important;
+  text-decoration: underline rgba(204, 68, 102, 0.4);
+  text-transform: none;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 21.6px;
+  word-break: break-word; /* safer than break-all */
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+}
+
+
+.form-section-alert {
+  color: #d97706;
+  font-size: 0.875rem;
+  display: none;
+}
+
+.form-section-header.collapsed .form-section-alert {
+  display: inline-block;
+}
+
+
+/* Validation */
+.form-error-alert {
+  color: #dc2626;
+  background-color: #fef2f2;
+  border-left: 4px solid #dc2626;
+  padding: 0.5rem;
+  margin-top: var(--space-xs);
+  font-size: 0.875rem;
+  border-radius: 6px;
+}
+
+.form-section-description {
+  margin-top: var(--space-sm);
+  font-size: 0.875rem;
+  color: var(--font-muted, #6B7280);
+}
+
+/* Buttons */
+button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  user-select: none;
+  vertical-align: middle;
+  appearance: none;
+  text-decoration: none;
+
+  /* Typography */
+  font-family: var(--font-family, 'Rubik', sans-serif);
+  font-size: var(--font-size-lg, 16px);
+  font-weight: 500;
+  text-transform: uppercase;
+  line-height: 1.4;
+
+  /* Sizing & Spacing */
+  min-width: 64px;
+  padding: 0.75rem 1.5rem;
+  width: fit-content;
+  margin-top: 1rem; /* adjust spacing as needed */
+
+
+  /* Colors & Styling */
+  background: linear-gradient(90deg, var(--primary-color), var(--accent-color));
+  color: #ffffff;
+  border: none;
+  border-radius: var(--radius, 6px);
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.1s ease;
+}
+
+button:hover,
+button:focus-visible {
+  background: linear-gradient(90deg, var(--primary-hover), var(--accent-color));
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.15);
+  transform: translateY(-1px);
+  outline: 3px solid rgba(204, 68, 102, 0.4);; /* focus ring for accessibility */
+  outline-offset: 2px;
+}
+
+button:disabled {
+  background-color: #9ca3af;
+  cursor: not-allowed;
+  color: #ffffff;
+  box-shadow: none;
+  transform: none;
+}
+
+
+.button-secondary {
+  width: fit-content;
+  padding: 0.75rem 1.5rem;
+  background: #ffffff;
+  color: #CC4466;
+  outline: 3px solid #CC4466;
+  outline-offset: -3px;
+  border: none;
+  border-radius: 0;
+  margin-top: 1rem; /* adjust spacing as needed */
+  text-transform: uppercase;
+  font-family: var(--font-family, 'Rubik', sans-serif);
+  font-size: var(--font-size-lg, 16px);
+  font-weight: 500;
+  line-height: 1.4;
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.1s ease;
+}
+
+.button-secondary:hover,
+.button-secondary:focus-visible {
+  background: #fef2f2;
+  transform: translateY(-1px);
+}
+
+/* Mobile Adjustments */
+@media (max-width: 768px) {
+  .wizard-layout-row {
+    flex-direction: column;
+  }
+  .form-main {
+    padding: 1rem;
+    height: auto;
+  }
+
+  .form-header,
+  .form-footer {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .hamburger {
+    display: block;
+  }
+
+  .form-header .right {
+    display: none;
+    flex-direction: column;
+    background: white;
+    position: absolute;
+    top: 3.5rem;
+    left: var(--space-md);
+    right: var(--space-md);
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    padding: var(--space-md);
+    z-index: 1000;
+  }
+
+  .form-header .right.open {
+    display: flex;
+  }
+
+  .form-header .right a {
+    margin: var(--space-sm) 0;
+  }
+}
+
+.required-asterisk {
+  color: red;
+  margin-left: var(--space-xs);
+  font-weight: bold;
+}
+
+.modern-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-size-sm); 
+  margin-top: var(--space-md);
+  margin-bottom: var(--space-md); 
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.modern-table th,
+.modern-table td {
+  border: 1px solid var(--border);
+  padding: var(--space-sm); 
+  text-align: left;
+  font-size: 18px;
+  font-family: 'Rubik', sans-serif;
+  font-weight: 500;
+}
+
+.modern-table th {
+  background-color: #eef2f7
+}
+
+.modern-table thead {
+  background-color: var(--background);
+}
+
+.modern-table tbody tr:nth-child(odd) {
+  background-color: var(--surface); 
+}
+
+.modern-table tbody tr:nth-child(even) {
+  background-color: var(--background); 
+}
+
+.modern-table tbody tr:hover {
+  background-color: var(--hover-surface, rgba(204, 68, 102, 0.08)); 
+}
+
+.modern-table button {
+  margin-right: var(--space-sm);
+}
+
+.copy-controls {
+  margin: var(--space-md) 0;
+  display: flex;
+  gap: var(--space-md);
+  align-items: center;
+}
+
+
+.form-group-wrapper {
+  margin-bottom: var(--space-lg);
+  padding: var(--space-md);
+  border-radius: 8px;
+  background-color: #f9fafb;
+  border: 1px solid #e5e7eb;
+}
+
+.group-columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-md);
+}
+
+.group-col {
+  min-width: 0;
+}
+
+.form-group-heading {
+  font-size: 1.1rem;
+  font-weight: 600;
+  background-color: #f3f4f6;
+  padding: var(--space-sm) var(--space-md);
+  border-radius: 6px;
+  margin-bottom: var(--space-md);
+  color: #111827;
+  border-left: 4px solid #3b82f6; /* Blue stripe */
+}
+
+
+
+
+/* Card layouts */
+
+.app-card{
+  text-decoration: none;
+  /* border-left: 4px solid #2563eb; */
+  border-left: 4px solid #10b981;
+  display: block;
+  padding: 1.25rem;
+  background-color: white;
+  border-radius: 0.5rem;
+  transition: all 0.25s ease-in-out;
+  color: #1a202c;
+  max-width: 320px;
+  text-align: left;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  margin-bottom: var(--space-md);
+
+}
+
+.app-card:hover,
+.app-card:focus {
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.15);
+  transform: translateY(-4px);
+  /* border-color: #2563eb; */
+  border-color: #10b981;
+  text-decoration: none;
+  background-color: #f9fafb;
+}
+
+
+.service-card{
+  text-decoration: none;
+  border-left: 4px solid #2563eb;
+  display: block;
+  padding: 1.25rem;
+  background-color: white;
+  border-radius: 0.5rem;
+  transition: all 0.25s ease-in-out;
+  color: #1a202c;
+  max-width: 320px;
+  text-align: left;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  margin-bottom: var(--space-md);
+
+}
+
+.service-card:hover,
+.service-card:focus {
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.15);
+  transform: translateY(-4px);
+  border-color: #2563eb; 
+  text-decoration: none;
+  background-color: #f9fafb;
+}
+
+
+.catalog-grid,
+.saved-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  margin-top: var(--space-md);
+}
+
+.card-title {
+  margin-top: 0;
+}
+
+.app-card-actions {
+  margin-top: var(--space-sm);
+  display: flex;
+  gap: var(--space-sm);
+}
+
+.app-card-actions button {
+  flex: 1;
+}
+
+input[type="text"],
+input[type="email"],
+input[type="password"],
+input[type="number"],
+input[type="tel"],
+input[type="date"],
+select,
+textarea {
+  font-family: var(--font-family, 'Rubik', sans-serif);
+  font-weight: 400;
+  font-size: 16px;
+  padding: 12px 16px;
+  z-index: 1;
+  width: 100%;
+
+  color: var(--font-color, #1F2937);
+  background-color: var(--surface, #FFFFFF);
+  border: 1px solid var(--border, #D1D5DB);
+  border-radius: var(--radius, 6px);
+  box-sizing: border-box;
+
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: var(--accent-color, #2684FF);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(38, 132, 255, 0.3);
+}
+
+input:disabled,
+select:disabled,
+textarea:disabled {
+  background-color: #f3f4f6;
+  color: #9ca3af;
+  cursor: not-allowed;
+}
+
+::placeholder {
+  color: var(--font-muted, #6B7280);
+  opacity: 1;
+}

--- a/childcare-app/styles/globals.css
+++ b/childcare-app/styles/globals.css
@@ -1,3 +1,6 @@
+@import './design-tokens.css';
+@import './form.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
## Summary
- import design-tokens and form styles globally
- apply global body theme via custom Document
- wrap app content in `.form-main`
- style form sections using token classes
- apply `.button-primary` and `.button-secondary` buttons
- clean up field components to rely on CSS tokens
- tweak Stepper colors to use CSS variables

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a52910c108331a9139af7e917faaf