### PR TITLE
Fix form validation behavior

### DIFF
--- a/childcare-app/components/FormRenderer.tsx
+++ b/childcare-app/components/FormRenderer.tsx
@@ -23,7 +23,7 @@ export default function FormRenderer() {
   const [stepIndex, setStepIndex] = useState(0)
   const stepFields = steps[stepIndex].sections?.flatMap((sec: any) => sec.fields || []) || []
   const schema = buildConditionalSchema(stepFields)
-  const methods = useForm({ mode: 'onBlur', resolver: async (values) => {
+  const methods = useForm({ mode: 'onBlur', shouldUnregister: true, resolver: async (values) => {
     try {
       const data = schema.parse(values)
       return { values: data, errors: {} }
@@ -52,7 +52,8 @@ export default function FormRenderer() {
   }
 
   const validateAndSave = async () => {
-    const valid = await methods.trigger()
+    const fieldIds = stepFields.map((f: FieldSpec) => f.id)
+    const valid = await methods.trigger(fieldIds)
     if (valid) {
       saveDraft()
     }

--- a/childcare-app/components/fields/CheckboxGroup.tsx
+++ b/childcare-app/components/fields/CheckboxGroup.tsx
@@ -11,7 +11,7 @@ interface Props {
   required?: boolean
 }
 export default function CheckboxGroup({ id, label, options, required }: Props) {
-  const { register, formState: { errors } } = useFormContext()
+  const { register, formState: { errors }, clearErrors } = useFormContext()
   return (
     <fieldset className="mb-4">
       <legend className="font-medium">
@@ -19,12 +19,12 @@ export default function CheckboxGroup({ id, label, options, required }: Props) {
       </legend>
       {options.map(opt => (
         <label key={opt.value} className="block">
-          <input type="checkbox" value={opt.value} {...register(id, { required })} className="mr-2" />
+          <input type="checkbox" value={opt.value} {...register(id, { required, onChange: () => clearErrors(id), onBlur: () => clearErrors(id) })} className="mr-2" />
           {opt.label}
         </label>
       ))}
       {errors[id] && (
-        <p className="form-error-alert">This field is required.</p>
+        <p className="form-error-alert">{errors[id].message as string}</p>
       )}
     </fieldset>
   )

--- a/childcare-app/components/fields/DateField.tsx
+++ b/childcare-app/components/fields/DateField.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 export default function DateField({ id, label, required, tooltip }: Props) {
 
-  const { register, formState: { errors } } = useFormContext()
+  const { register, formState: { errors }, clearErrors } = useFormContext()
   return (
     <div className="mb-4">
       <label htmlFor={id} className="block font-medium">
@@ -16,13 +16,13 @@ export default function DateField({ id, label, required, tooltip }: Props) {
       </label>
       {tooltip ? (
         <Tooltip content={tooltip}>
-          <input id={id} type="date" title={tooltip} {...register(id, { required })} className="w-full" />
+          <input id={id} type="date" title={tooltip} {...register(id, { required, onChange: () => clearErrors(id), onBlur: () => clearErrors(id) })} className="w-full" />
         </Tooltip>
       ) : (
-        <input id={id} type="date" title={tooltip} {...register(id, { required })} className="w-full" />
+        <input id={id} type="date" title={tooltip} {...register(id, { required, onChange: () => clearErrors(id), onBlur: () => clearErrors(id) })} className="w-full" />
       )}
       {errors[id] && (
-        <p className="form-error-alert">This field is required.</p>
+        <p className="form-error-alert">{errors[id].message as string}</p>
       )}
     </div>
   )

--- a/childcare-app/components/fields/FileUploadField.tsx
+++ b/childcare-app/components/fields/FileUploadField.tsx
@@ -13,7 +13,7 @@ interface Props {
   }
 }
 export default function FileUploadField({ id, label, required, multiple, accept, maxFileSizeMB, imageResolution }: Props) {
-  const { register, setValue, formState: { errors } } = useFormContext()
+  const { register, setValue, formState: { errors }, clearErrors } = useFormContext()
   const [dragging, setDragging] = useState(false)
 
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
@@ -43,6 +43,8 @@ export default function FileUploadField({ id, label, required, multiple, accept,
           type="file"
           {...register(id, {
           required,
+          onChange: () => clearErrors(id),
+          onBlur: () => clearErrors(id),
           validate: async (fileList) => {
             const file = (fileList as FileList)[0]
             if (!file) return true

--- a/childcare-app/components/fields/InfoBlock.tsx
+++ b/childcare-app/components/fields/InfoBlock.tsx
@@ -10,6 +10,7 @@ interface Props {
 
 export default function InfoBlock({ title, content, collapsible, defaultCollapsed }: Props) {
   const [collapsed, setCollapsed] = useState<boolean>(defaultCollapsed ?? false)
+  const parsedContent = content.replace(/\\n/g, '\n')
 
   return (
     <div className="mb-6 p-4 bg-blue-50 border-l-4 border-blue-400">
@@ -22,7 +23,7 @@ export default function InfoBlock({ title, content, collapsible, defaultCollapse
         )}
       </div>
       {(!collapsible || !collapsed) && (
-        <ReactMarkdown>{content}</ReactMarkdown>
+        <ReactMarkdown>{parsedContent}</ReactMarkdown>
       )}
     </div>
   )

--- a/childcare-app/components/fields/RadioGroup.tsx
+++ b/childcare-app/components/fields/RadioGroup.tsx
@@ -6,7 +6,7 @@ interface Props {
   required?: boolean;
 }
 export default function RadioGroup({ id, label, options, required }: Props) {
-  const { register, formState: { errors } } = useFormContext()
+  const { register, formState: { errors }, clearErrors } = useFormContext()
   return (
     <fieldset className="mb-4">
       <legend className="font-medium">
@@ -14,12 +14,12 @@ export default function RadioGroup({ id, label, options, required }: Props) {
       </legend>
       {options.map(opt => (
         <label key={opt} className="block">
-          <input type="radio" value={opt} {...register(id, { required })} className="mr-2" />
+          <input type="radio" value={opt} {...register(id, { required, onChange: () => clearErrors(id), onBlur: () => clearErrors(id) })} className="mr-2" />
           {opt}
         </label>
       ))}
       {errors[id] && (
-        <p className="form-error-alert">This field is required.</p>
+        <p className="form-error-alert">{errors[id].message as string}</p>
       )}
     </fieldset>
   )

--- a/childcare-app/components/fields/SelectField.tsx
+++ b/childcare-app/components/fields/SelectField.tsx
@@ -9,7 +9,7 @@ interface Props {
   tooltip?: string
 }
 export default function SelectField({ id, label, options, required, multiple, tooltip }: Props) {
-  const { register, formState: { errors }, setValue } = useFormContext()
+  const { register, formState: { errors }, setValue, clearErrors } = useFormContext()
 
   return (
     <div className="mb-4">
@@ -25,11 +25,13 @@ export default function SelectField({ id, label, options, required, multiple, to
             {...register(id, {
               required,
               onChange: e => {
+                clearErrors(id)
                 if (multiple) {
                   const vals = Array.from(e.target.selectedOptions).map(o => o.value)
                   setValue(id, vals)
                 }
-              }
+              },
+              onBlur: () => clearErrors(id)
             })}
             className="w-full"
           >
@@ -46,11 +48,12 @@ export default function SelectField({ id, label, options, required, multiple, to
           multiple={multiple}
           title={tooltip}
           {...register(id, { required, onChange: e => {
+            clearErrors(id)
             if (multiple) {
               const vals = Array.from(e.target.selectedOptions).map(o => o.value)
               setValue(id, vals)
             }
-          } })}
+          }, onBlur: () => clearErrors(id) })}
           className="w-full"
         >
           {!multiple && <option value="">Select...</option>}
@@ -61,7 +64,7 @@ export default function SelectField({ id, label, options, required, multiple, to
         </select>
       )}
       {errors[id] && (
-        <p className="form-error-alert">This field is required.</p>
+        <p className="form-error-alert">{errors[id].message as string}</p>
       )}
     </div>
   )

--- a/childcare-app/components/fields/TextField.tsx
+++ b/childcare-app/components/fields/TextField.tsx
@@ -11,7 +11,7 @@ interface Props {
   pattern?: string
 }
 export default function TextField({ id, label, type = 'text', required, placeholder, tooltip, pattern }: Props) {
-  const { register, formState: { errors } } = useFormContext()
+  const { register, formState: { errors }, clearErrors } = useFormContext()
   let regex: RegExp | undefined
   if (pattern) {
     try {
@@ -20,7 +20,7 @@ export default function TextField({ id, label, type = 'text', required, placehol
       console.warn('Invalid regex pattern:', pattern)
     }
   }
-  const validation = { required, pattern: regex }
+  const validation = { required, pattern: regex, onChange: () => clearErrors(id), onBlur: () => clearErrors(id) }
 
   return (
     <div className="mb-4">
@@ -49,7 +49,7 @@ export default function TextField({ id, label, type = 'text', required, placehol
         />
       )}
       {errors[id] && (
-        <p className="form-error-alert">This field is required.</p>
+        <p className="form-error-alert">{errors[id].message as string}</p>
       )}
     </div>
   )

--- a/childcare-app/components/fields/TimeField.tsx
+++ b/childcare-app/components/fields/TimeField.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 export default function TimeField({ id, label, required, tooltip }: Props) {
 
-  const { register, formState: { errors } } = useFormContext()
+  const { register, formState: { errors }, clearErrors } = useFormContext()
   return (
     <div className="mb-4">
       <label htmlFor={id} className="block font-medium">
@@ -16,14 +16,14 @@ export default function TimeField({ id, label, required, tooltip }: Props) {
       </label>
       {tooltip ? (
         <Tooltip content={tooltip}>
-          <input id={id} type="time" title={tooltip} {...register(id, { required })} className="w-full" />
+          <input id={id} type="time" title={tooltip} {...register(id, { required, onChange: () => clearErrors(id), onBlur: () => clearErrors(id) })} className="w-full" />
         </Tooltip>
       ) : (
-        <input id={id} type="time" title={tooltip} {...register(id, { required })} className="w-full" />
+        <input id={id} type="time" title={tooltip} {...register(id, { required, onChange: () => clearErrors(id), onBlur: () => clearErrors(id) })} className="w-full" />
       )}
 
       {errors[id] && (
-        <p className="form-error-alert">This field is required.</p>
+        <p className="form-error-alert">{errors[id].message as string}</p>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- parse `\n` in info blocks for markdown
- clear field errors on change
- display validation messages
- restrict validation to visible step fields
- unregister hidden fields when stepping

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a599d0a9483319b204175418787aa