### PR TITLE
Fix form field validation and markdown lists

### DIFF
--- a/childcare-app/components/fields/CheckboxGroup.tsx
+++ b/childcare-app/components/fields/CheckboxGroup.tsx
@@ -1,4 +1,5 @@
 import { useFormContext } from 'react-hook-form'
+import { getError } from '../../utils/getError'
 
 interface Option {
   value: string
@@ -12,6 +13,7 @@ interface Props {
 }
 export default function CheckboxGroup({ id, label, options, required }: Props) {
   const { register, formState: { errors }, clearErrors } = useFormContext()
+  const error = getError(errors, id)
   return (
     <fieldset className="mb-4">
       <legend className="font-medium">
@@ -23,8 +25,8 @@ export default function CheckboxGroup({ id, label, options, required }: Props) {
           {opt.label}
         </label>
       ))}
-      {errors[id] && (
-        <p className="form-error-alert">{errors[id].message as string}</p>
+      {error && (
+        <p className="form-error-alert">{(error as any).message as string}</p>
       )}
     </fieldset>
   )

--- a/childcare-app/components/fields/DateField.tsx
+++ b/childcare-app/components/fields/DateField.tsx
@@ -1,5 +1,6 @@
 import { useFormContext } from 'react-hook-form'
 import Tooltip from './Tooltip'
+import { getError } from '../../utils/getError'
 interface Props {
   id: string
   label: string
@@ -9,6 +10,7 @@ interface Props {
 export default function DateField({ id, label, required, tooltip }: Props) {
 
   const { register, formState: { errors }, clearErrors } = useFormContext()
+  const error = getError(errors, id)
   return (
     <div className="mb-4">
       <label htmlFor={id} className="block font-medium">
@@ -21,8 +23,8 @@ export default function DateField({ id, label, required, tooltip }: Props) {
       ) : (
         <input id={id} type="date" title={tooltip} {...register(id, { required, onChange: () => clearErrors(id), onBlur: () => clearErrors(id) })} className="w-full" />
       )}
-      {errors[id] && (
-        <p className="form-error-alert">{errors[id].message as string}</p>
+      {error && (
+        <p className="form-error-alert">{(error as any).message as string}</p>
       )}
     </div>
   )

--- a/childcare-app/components/fields/FileUploadField.tsx
+++ b/childcare-app/components/fields/FileUploadField.tsx
@@ -1,5 +1,6 @@
 import { useFormContext } from 'react-hook-form'
 import { useState } from 'react'
+import { getError } from '../../utils/getError'
 interface Props {
   id: string
   label: string
@@ -14,6 +15,7 @@ interface Props {
 }
 export default function FileUploadField({ id, label, required, multiple, accept, maxFileSizeMB, imageResolution }: Props) {
   const { register, setValue, formState: { errors }, clearErrors } = useFormContext()
+  const error = getError(errors, id)
   const [dragging, setDragging] = useState(false)
 
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
@@ -88,8 +90,8 @@ export default function FileUploadField({ id, label, required, multiple, accept,
           className="block mx-auto mt-2"
         />
       </div>
-      {errors[id] && (
-        <p className="form-error-alert">{errors[id].message as string}</p>
+      {error && (
+        <p className="form-error-alert">{(error as any).message as string}</p>
       )}
     </div>
   )

--- a/childcare-app/components/fields/InfoBlock.tsx
+++ b/childcare-app/components/fields/InfoBlock.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 
 interface Props {
   title: string
@@ -23,7 +24,7 @@ export default function InfoBlock({ title, content, collapsible, defaultCollapse
         )}
       </div>
       {(!collapsible || !collapsed) && (
-        <ReactMarkdown>{parsedContent}</ReactMarkdown>
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{parsedContent}</ReactMarkdown>
       )}
     </div>
   )

--- a/childcare-app/components/fields/RadioGroup.tsx
+++ b/childcare-app/components/fields/RadioGroup.tsx
@@ -1,4 +1,5 @@
 import { useFormContext } from 'react-hook-form'
+import { getError } from '../../utils/getError'
 interface Props {
   id: string;
   label: string;
@@ -7,6 +8,7 @@ interface Props {
 }
 export default function RadioGroup({ id, label, options, required }: Props) {
   const { register, formState: { errors }, clearErrors } = useFormContext()
+  const error = getError(errors, id)
   return (
     <fieldset className="mb-4">
       <legend className="font-medium">
@@ -18,8 +20,8 @@ export default function RadioGroup({ id, label, options, required }: Props) {
           {opt}
         </label>
       ))}
-      {errors[id] && (
-        <p className="form-error-alert">{errors[id].message as string}</p>
+      {error && (
+        <p className="form-error-alert">{(error as any).message as string}</p>
       )}
     </fieldset>
   )

--- a/childcare-app/components/fields/SelectField.tsx
+++ b/childcare-app/components/fields/SelectField.tsx
@@ -1,5 +1,6 @@
 import { useFormContext } from 'react-hook-form'
 import Tooltip from './Tooltip'
+import { getError } from '../../utils/getError'
 interface Props {
   id: string
   label: string
@@ -10,6 +11,7 @@ interface Props {
 }
 export default function SelectField({ id, label, options, required, multiple, tooltip }: Props) {
   const { register, formState: { errors }, setValue, clearErrors } = useFormContext()
+  const error = getError(errors, id)
 
   return (
     <div className="mb-4">
@@ -63,8 +65,8 @@ export default function SelectField({ id, label, options, required, multiple, to
           ))}
         </select>
       )}
-      {errors[id] && (
-        <p className="form-error-alert">{errors[id].message as string}</p>
+      {error && (
+        <p className="form-error-alert">{(error as any).message as string}</p>
       )}
     </div>
   )

--- a/childcare-app/components/fields/TextField.tsx
+++ b/childcare-app/components/fields/TextField.tsx
@@ -1,4 +1,5 @@
 import { useFormContext } from 'react-hook-form'
+import { getError } from '../../utils/getError'
 import Tooltip from './Tooltip'
 import { sanitizePattern } from '../../utils/regex'
 interface Props {
@@ -21,6 +22,7 @@ export default function TextField({ id, label, type = 'text', required, placehol
     }
   }
   const validation = { required, pattern: regex, onChange: () => clearErrors(id), onBlur: () => clearErrors(id) }
+  const error = getError(errors, id)
 
   return (
     <div className="mb-4">
@@ -32,7 +34,7 @@ export default function TextField({ id, label, type = 'text', required, placehol
           <input
             id={id}
             type={type}
-            title={tooltip}
+            title={tooltip || placeholder}
             {...register(id, validation)}
             placeholder={placeholder}
             className="w-full"
@@ -42,14 +44,14 @@ export default function TextField({ id, label, type = 'text', required, placehol
         <input
           id={id}
           type={type}
-          title={tooltip}
+          title={tooltip || placeholder}
           {...register(id, validation)}
           placeholder={placeholder}
           className="w-full"
         />
       )}
-      {errors[id] && (
-        <p className="form-error-alert">{errors[id].message as string}</p>
+      {error && (
+        <p className="form-error-alert">{(error as any).message as string}</p>
       )}
     </div>
   )

--- a/childcare-app/components/fields/TimeField.tsx
+++ b/childcare-app/components/fields/TimeField.tsx
@@ -1,5 +1,6 @@
 import { useFormContext } from 'react-hook-form'
 import Tooltip from './Tooltip'
+import { getError } from '../../utils/getError'
 interface Props {
   id: string
   label: string
@@ -9,6 +10,7 @@ interface Props {
 export default function TimeField({ id, label, required, tooltip }: Props) {
 
   const { register, formState: { errors }, clearErrors } = useFormContext()
+  const error = getError(errors, id)
   return (
     <div className="mb-4">
       <label htmlFor={id} className="block font-medium">
@@ -22,8 +24,8 @@ export default function TimeField({ id, label, required, tooltip }: Props) {
         <input id={id} type="time" title={tooltip} {...register(id, { required, onChange: () => clearErrors(id), onBlur: () => clearErrors(id) })} className="w-full" />
       )}
 
-      {errors[id] && (
-        <p className="form-error-alert">{errors[id].message as string}</p>
+      {error && (
+        <p className="form-error-alert">{(error as any).message as string}</p>
       )}
     </div>
   )

--- a/childcare-app/package.json
+++ b/childcare-app/package.json
@@ -16,7 +16,8 @@
     "react-hook-form": "7.49.2",
     "zod": "3.22.4",
     "@hookform/resolvers": "^3.0.0",
-    "react-markdown": "latest"
+    "react-markdown": "latest",
+    "remark-gfm": "latest"
   },
   "devDependencies": {
     "@types/react": "18.2.12",

--- a/childcare-app/styles/form.css
+++ b/childcare-app/styles/form.css
@@ -159,6 +159,18 @@ h5 {
   border-radius: 6px;
 }
 
+ul {
+  list-style: disc;
+  margin-left: 1.25rem;
+  padding-left: 1rem;
+}
+
+ol {
+  list-style: decimal;
+  margin-left: 1.25rem;
+  padding-left: 1rem;
+}
+
 .form-section-description {
   margin-top: var(--space-sm);
   font-size: 0.875rem;

--- a/childcare-app/utils/getError.ts
+++ b/childcare-app/utils/getError.ts
@@ -1,0 +1,3 @@
+export function getError(obj: any, path: string) {
+  return path.split('.').reduce((acc, part) => acc && acc[part], obj)
+}


### PR DESCRIPTION
## Summary
- clear nested field errors using `getError` utility
- show placeholder hints in text fields
- support GitHub Flavored Markdown lists
- style bullet and numbered lists

## Testing
- `npm test --prefix childcare-app` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a5c137c6883319a0be9e347a15582