### PR TITLE
Fix placeholders for SSN and phone

### DIFF
--- a/childcare-app/components/FormRenderer.tsx
+++ b/childcare-app/components/FormRenderer.tsx
@@ -83,12 +83,43 @@ export default function FormRenderer() {
     }
     switch (f.type) {
       case 'text':
-        return <TextField key={f.id} id={f.id} label={f.label || ''} required={f.required} placeholder={f.placeholder} tooltip={f.tooltip} pattern={f.constraints?.pattern} />
+        return (
+          <TextField
+            key={f.id}
+            id={f.id}
+            label={f.label || ''}
+            required={f.required}
+            placeholder={f.placeholder || f.ui?.placeholder}
+            tooltip={f.tooltip}
+            pattern={f.constraints?.pattern}
+          />
+        )
       case 'tel':
       case 'email':
-        return <TextField key={f.id} id={f.id} type={f.type} label={f.label || ''} required={f.required} placeholder={f.placeholder} tooltip={f.tooltip} pattern={f.constraints?.pattern} />
+        return (
+          <TextField
+            key={f.id}
+            id={f.id}
+            type={f.type}
+            label={f.label || ''}
+            required={f.required}
+            placeholder={f.placeholder || f.ui?.placeholder}
+            tooltip={f.tooltip}
+            pattern={f.constraints?.pattern}
+          />
+        )
       case 'number':
-        return <TextField key={f.id} id={f.id} type="number" label={f.label || ''} required={f.required} placeholder={f.placeholder} tooltip={f.tooltip} />
+        return (
+          <TextField
+            key={f.id}
+            id={f.id}
+            type="number"
+            label={f.label || ''}
+            required={f.required}
+            placeholder={f.placeholder || f.ui?.placeholder}
+            tooltip={f.tooltip}
+          />
+        )
       case 'select':
         return <SelectField key={f.id} id={f.id} label={f.label || ''} options={Array.isArray(f.ui?.options) ? f.ui.options : []} required={f.required} multiple={f.metadata?.multiple} tooltip={f.tooltip} />
 

--- a/childcare-app/types/field.ts
+++ b/childcare-app/types/field.ts
@@ -6,7 +6,12 @@ export interface FieldSpec {
   required?: boolean
   requiredCondition?: any
   visibilityCondition?: any
-  ui?: { options?: any; collapsible?: boolean; defaultCollapsed?: boolean }
+  ui?: {
+    options?: any
+    collapsible?: boolean
+    defaultCollapsed?: boolean
+    placeholder?: string
+  }
   placeholder?: string
   content?: string
   metadata?: { multiple?: boolean; proofCategory?: string }


### PR DESCRIPTION
## Summary
- expose placeholder in `FieldSpec.ui`
- show placeholders from spec in form renderer

## Testing
- `npm test --prefix childcare-app` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a6024d11c8331acdd821452eaf24f