### PR TITLE
Add mapZodErrors utility and validation test

### DIFF
--- a/childcare-app/__tests__/form-renderer-errors.test.tsx
+++ b/childcare-app/__tests__/form-renderer-errors.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { z } from 'zod'
+import TextField from '../components/fields/TextField'
+import mapZodErrors from '../utils/mapZodErrors'
+
+describe('Form error display', () => {
+  function TestForm() {
+    const schema = z.object({ name: z.string().nonempty('Required') })
+    const methods = useForm({
+      resolver: async values => {
+        try {
+          const data = schema.parse(values)
+          return { values: data, errors: {} }
+        } catch (e: any) {
+          return { values: {}, errors: mapZodErrors(e.formErrors.fieldErrors) }
+        }
+      }
+    })
+    return (
+      <FormProvider {...methods}>
+        <form onSubmit={methods.handleSubmit(() => {})}>
+          <TextField id="name" label="Name" required />
+          <button type="submit">Submit</button>
+        </form>
+      </FormProvider>
+    )
+  }
+
+  it('shows validation message on submit', async () => {
+    render(<TestForm />)
+    fireEvent.click(screen.getByText('Submit'))
+    expect(await screen.findByText('Required')).toBeInTheDocument()
+  })
+})

--- a/childcare-app/components/FormRenderer.tsx
+++ b/childcare-app/components/FormRenderer.tsx
@@ -13,6 +13,7 @@ import Stepper from '../features/Stepper'
 import formSpec from '../childcare_form.json'
 import { evaluateCondition } from '../utils/conditions'
 import { buildConditionalSchema } from '../utils/schemaBuilder'
+import mapZodErrors from '../utils/mapZodErrors'
 import GroupField from './GroupField'
 import { FieldSpec } from '../types/field'
 
@@ -28,7 +29,7 @@ export default function FormRenderer() {
       const data = schema.parse(values)
       return { values: data, errors: {} }
     } catch (e: any) {
-      return { values: {}, errors: e.formErrors.fieldErrors }
+      return { values: {}, errors: mapZodErrors(e.formErrors.fieldErrors) }
     }
   } })
 

--- a/childcare-app/utils/mapZodErrors.ts
+++ b/childcare-app/utils/mapZodErrors.ts
@@ -1,0 +1,27 @@
+/**
+ * Recursively converts Zod's flattened fieldErrors object into the
+ * shape expected by react-hook-form. Strings are wrapped in an object
+ * `{ message: string }` and nested arrays are traversed so that group
+ * fields return arrays of objects with the same structure.
+ */
+export default function mapZodErrors(errors: any): any {
+  if (Array.isArray(errors)) {
+    // Array of error messages for primitive fields
+    if (errors.length > 0 && typeof errors[0] === 'string') {
+      return { message: errors[0] }
+    }
+    // Array of nested objects, e.g. groups with `multiple: true`
+    return errors.map(e => mapZodErrors(e))
+  }
+  if (errors && typeof errors === 'object') {
+    const out: Record<string, any> = {}
+    for (const [key, value] of Object.entries(errors)) {
+      out[key] = mapZodErrors(value)
+    }
+    return out
+  }
+  if (typeof errors === 'string') {
+    return { message: errors }
+  }
+  return errors
+}


### PR DESCRIPTION
## Summary
- create `mapZodErrors` utility to normalize Zod errors
- use it inside `FormRenderer` resolver
- test that validation errors display with react-hook-form

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a62597ae08331b51bb57fd8df9e09